### PR TITLE
Plugins option depreciated - docs updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,21 @@
 Disqus integration for GitBook
 ==============
 
-You can use install it via **NPM**:
+Install the Disqus plugin via **NPM**, which should be installed globally using the `-g` option:
 
 ```
-$ npm install gitbook-plugin-disqus
+$ npm install gitbook-plugin-disqus -g
 ```
 
-And use it for your book with:
-
-```
-$ gitbook build ./ --plugins=disqus
-```
+> As you are installing globally, you may need to put `sudo` in front of the command, `sudo npm install gitbook-plugin-disqus -g`
 
 
-You can set the Disqus shortname using the plugins configuration in the book.json:
+To use the Disqus plugin in your Gitbook project, add the disqus plugin to the `book.json` file, along with your shortname (you create a shortname for disqus by creating a new website on the [disqus.com](https://disqus.com/) website)
 
 ```
 {
-    plugins: ["disqus"],
-    pluginsConfig: {
+    "plugins": ["disqus"],
+    "pluginsConfig": {
         "disqus": {
             "shortName": "XXXXXXX"
         }
@@ -27,3 +23,6 @@ You can set the Disqus shortname using the plugins configuration in the book.jso
 }
 ```
 
+> The --plugins option to the Gitbook `serve` and `build` commands has been depreciated.
+
+Thank you.


### PR DESCRIPTION
Plugins are only supported by adding the disqus plugin into the book.js file.  The previous method of using --plugins is depreciated.
