### PR TITLE
Use document name as identifier

### DIFF
--- a/book/plugin.js
+++ b/book/plugin.js
@@ -16,7 +16,7 @@ require([
             DISQUS.reset({
                 reload: true,
                 config: function () {  
-                    this.language = "en";  
+                    this.language = $('html').attr('lang') || "en";
                     this.page.url = window.location.href;
 
                     if (use_identifier) {

--- a/book/plugin.js
+++ b/book/plugin.js
@@ -1,4 +1,11 @@
-require(["gitbook", "jQuery"], function(gitbook, $) {
+require([
+    "gitbook",
+    "jQuery",
+    "URIjs/URI",
+    "utils/url",
+], function(gitbook, $, URI, URL) {
+    var use_identifier = false;
+
     var resetDisqus = function() {
         var $disqusDiv = $("<div>", {
             "id": "disqus_thread"
@@ -11,16 +18,41 @@ require(["gitbook", "jQuery"], function(gitbook, $) {
                 config: function () {  
                     this.language = "en";  
                     this.page.url = window.location.href;
+
+                    if (use_identifier) {
+                        this.page.identifier = currentUrl();
+                    }
                 }
             });
         }
-    }
+    };
+
+    var currentUrl = function() {
+        var location = new URI(window.location.href),
+            base     = URL.join(window.location.href, gitbook.state.basePath),
+            current  = location.relativeTo(base).toString(),
+            language = $('html').attr('lang'),
+            parent   = URL.dirname(base),
+            folder   = new URI(base).relativeTo(parent).toString();
+
+        // If parent folder is the same as language, we assume translated books
+        if (folder.replace(/\/$/, "") === language) {
+            current = folder + current;
+        }
+
+        return current;
+    };
 
     gitbook.events.bind("start", function(e, config) {
         config.disqus = config.disqus || {};
         var disqus_shortname = config.disqus.shortName;
 
-         /* * * DON'T EDIT BELOW THIS LINE * * */
+        if (config.disqus.useIdentifier) {
+            use_identifier = true;
+            var disqus_identifier = currentUrl();
+        }
+
+        /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
             dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';

--- a/book/plugin.js
+++ b/book/plugin.js
@@ -46,6 +46,9 @@ require([
     gitbook.events.bind("start", function(e, config) {
         config.disqus = config.disqus || {};
         var disqus_shortname = config.disqus.shortName;
+        var disqus_config = function() {
+            this.language = $('html').attr('lang') || "en";
+        };
 
         if (config.disqus.useIdentifier) {
             use_identifier = true;


### PR DESCRIPTION
This PR adds a config option `useIdentifier`. If enabled, the Disqus platform will use the current document name (relative to the book base path) as identifier. If the same book is served from multiple places, this will load the same comments for the same page.

Additionally, I have fixed the language, which was always set to english. Now we're using the HTML document language instead.